### PR TITLE
removed space at beginning

### DIFF
--- a/elements/_all.sass
+++ b/elements/_all.sass
@@ -1,4 +1,4 @@
- /* Bulma Elements */
+/* Bulma Elements */
 @charset "utf-8"
 
 @import "~bulma/sass/elements/box.sass"


### PR DESCRIPTION
The webpack compiler gets angry if I include .sass files with spaces at beginning.